### PR TITLE
Transform nullOutSpilledVariable to see the value of the spilled object

### DIFF
--- a/src/main/java/com/intellij/rt/debugger/agent/DebuggerAgent.java
+++ b/src/main/java/com/intellij/rt/debugger/agent/DebuggerAgent.java
@@ -31,6 +31,7 @@ public class DebuggerAgent {
     CaptureAgent.init(properties, instrumentation);
     SuspendHelper.init(properties);
     CollectionBreakpointInstrumentor.init(instrumentation);
+    SpilledVariablesTransformer.init(instrumentation);
   }
 
   private static void readAndApplyProperties(String uri, Instrumentation instrumentation) {

--- a/src/main/java/com/intellij/rt/debugger/agent/SpilledVariablesTransformer.java
+++ b/src/main/java/com/intellij/rt/debugger/agent/SpilledVariablesTransformer.java
@@ -6,8 +6,20 @@ import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.Instrumentation;
 import java.security.ProtectionDomain;
 
-import static org.jetbrains.capture.org.objectweb.asm.Opcodes.F_SAME;
-
+/**
+ * This transformer allows to see the value of a spilled local variable after the suspension point (see KT-63720).
+ * Fixes the problem of "optimized out local variable".
+ *
+ * When a visible dead object variable is spilled, Kotlin compiler generates the call to kotlin.coroutines.jvm.internal.SpillingKt#nullOutSpilledVariable,
+ * it takes the current value of the variable as an argument and returns null by default.
+ * ```
+ * fun nullOutSpilledVariable(value: Any?): Any? = null
+ * ```
+ * [NullOutSpilledVariableTransformer] transforms this function, so that it returns it's argument value, the current value of the variable.
+ * ```
+ * fun nullOutSpilledVariable(value: Any?): Any? = value
+ * ```
+ */
 public class SpilledVariablesTransformer {
     public static void init(Instrumentation instrumentation) {
         if (Boolean.getBoolean("debugger.agent.enable.coroutines")) {
@@ -15,20 +27,6 @@ public class SpilledVariablesTransformer {
         }
     }
 
-    /**
-     * This transformer allows to see the value of a spilled local variable after the suspension point (see KT-63720).
-     * Fixes the problem of "optimized out local variable".
-     *
-     * When a visible dead object variable is spilled, Kotlin compiler generates the call to kotlin.coroutines.jvm.internal.SpillingKt#nullOutSpilledVariable,
-     * it takes the current value of the variable as an argument and returns null by default.
-     * ```
-     * fun nullOutSpilledVariable(value: Any?): Any? = null
-     * ```
-     * [NullOutSpilledVariableTransformer] transforms this function, so that it returns it's argument value, the current value of the variable.
-     * ```
-     * fun nullOutSpilledVariable(value: Any?): Any? = value
-     * ```
-     */
     private static class SpillingTransformer implements ClassFileTransformer {
         @Override
         public byte[] transform(final ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) {
@@ -37,13 +35,22 @@ public class SpilledVariablesTransformer {
             }
             try {
                 ClassReader reader = new ClassReader(classfileBuffer);
-                ClassWriter writer = new ClassWriter(reader, 0);
+                ClassWriter writer = new ClassWriter(reader, ClassWriter.COMPUTE_FRAMES);
                 reader.accept(new ClassVisitor(Opcodes.API_VERSION, writer) {
                     @Override
                     public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
-                        MethodVisitor mv = super.visitMethod(access, name, descriptor, signature, exceptions);
-                        if ("nullOutSpilledVariable".equals(name)) return new NullOutSpilledVariableTransformer(mv);
-                        return mv;
+                        MethodVisitor superMethodVisitor = super.visitMethod(access, name, descriptor, signature, exceptions);
+                        if (name.equals("nullOutSpilledVariable")) {
+                            return new MethodVisitor(Opcodes.API_VERSION, superMethodVisitor) {
+                                @Override
+                                public void visitCode() {
+                                    super.visitCode();
+                                    mv.visitVarInsn(Opcodes.ALOAD, 0);
+                                    mv.visitInsn(Opcodes.ARETURN);
+                                }
+                            };
+                        }
+                        return superMethodVisitor;
                     }
                 }, 0);
                 byte[] bytes = writer.toByteArray();
@@ -54,22 +61,6 @@ public class SpilledVariablesTransformer {
                 e.printStackTrace();
             }
             return null;
-        }
-
-        private static class NullOutSpilledVariableTransformer extends MethodVisitor {
-            public NullOutSpilledVariableTransformer(MethodVisitor mv) {
-                super(Opcodes.API_VERSION, mv);
-            }
-            @Override
-            public void visitCode() {
-                super.visitCode();
-
-                mv.visitVarInsn(Opcodes.ALOAD, 0);
-                mv.visitInsn(Opcodes.ARETURN);
-                mv.visitFrame(F_SAME, 0, null, 0, null);
-                mv.visitMaxs(1, 1);
-                mv.visitEnd();
-            }
         }
     }
 }

--- a/src/main/java/com/intellij/rt/debugger/agent/SpilledVariablesTransformer.java
+++ b/src/main/java/com/intellij/rt/debugger/agent/SpilledVariablesTransformer.java
@@ -1,0 +1,62 @@
+package com.intellij.rt.debugger.agent;
+
+import org.jetbrains.capture.org.objectweb.asm.*;
+
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.Instrumentation;
+import java.security.ProtectionDomain;
+
+import static org.jetbrains.capture.org.objectweb.asm.Opcodes.F_SAME;
+
+public class SpilledVariablesTransformer {
+    public static void init(Instrumentation instrumentation) {
+        if (Boolean.getBoolean("debugger.agent.enable.coroutines")) {
+            instrumentation.addTransformer(new SpillingTransformer(), true);
+        }
+    }
+
+    private static class SpillingTransformer implements ClassFileTransformer {
+        @Override
+        public byte[] transform(final ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) {
+            if (!"kotlin/coroutines/jvm/internal/SpillingKt".equals(className)) {
+                return classfileBuffer;
+            }
+            try {
+                ClassReader reader = new ClassReader(classfileBuffer);
+                ClassWriter writer = new ClassWriter(reader, 0);
+                reader.accept(new ClassVisitor(Opcodes.API_VERSION, writer) {
+                    @Override
+                    public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+                        MethodVisitor mv = super.visitMethod(access, name, descriptor, signature, exceptions);
+                        if ("nullOutSpilledVariable".equals(name)) return new NullOutSpilledVariableTransformer(mv);
+                        return mv;
+                    }
+                }, 0);
+                byte[] bytes = writer.toByteArray();
+                CaptureAgent.storeClassForDebug(className, bytes);
+                return bytes;
+            } catch (Exception e) {
+                System.out.println("SpillingTransformer: failed to instrument " + className);
+                e.printStackTrace();
+            }
+            return null;
+        }
+
+        private static class NullOutSpilledVariableTransformer extends MethodVisitor {
+            public NullOutSpilledVariableTransformer(MethodVisitor mv) {
+                super(Opcodes.API_VERSION, mv);
+            }
+
+            @Override
+            public void visitCode() {
+                super.visitCode();
+
+                mv.visitVarInsn(Opcodes.ALOAD, 0);
+                mv.visitInsn(Opcodes.ARETURN);
+                mv.visitFrame(F_SAME, 0, null, 0, null);
+                mv.visitMaxs(1, 1);
+                mv.visitEnd();
+            }
+        }
+    }
+}

--- a/src/main/java/com/intellij/rt/debugger/agent/SpilledVariablesTransformer.java
+++ b/src/main/java/com/intellij/rt/debugger/agent/SpilledVariablesTransformer.java
@@ -41,7 +41,7 @@ public class SpilledVariablesTransformer {
                     public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
                         MethodVisitor superMethodVisitor = super.visitMethod(access, name, descriptor, signature, exceptions);
                         if (name.equals("nullOutSpilledVariable")) {
-                            return new MethodVisitor(Opcodes.API_VERSION, superMethodVisitor) {
+                            return new MethodVisitor(api, superMethodVisitor) {
                                 @Override
                                 public void visitCode() {
                                     super.visitCode();

--- a/src/main/java/com/intellij/rt/debugger/agent/SpilledVariablesTransformer.java
+++ b/src/main/java/com/intellij/rt/debugger/agent/SpilledVariablesTransformer.java
@@ -15,6 +15,20 @@ public class SpilledVariablesTransformer {
         }
     }
 
+    /**
+     * This transformer allows to see the value of a spilled local variable after the suspension point (see KT-63720).
+     * Fixes the problem of "optimized out local variable".
+     *
+     * When a visible dead object variable is spilled, Kotlin compiler generates the call to kotlin.coroutines.jvm.internal.SpillingKt#nullOutSpilledVariable,
+     * it takes the current value of the variable as an argument and returns null by default.
+     * ```
+     * fun nullOutSpilledVariable(value: Any?): Any? = null
+     * ```
+     * [NullOutSpilledVariableTransformer] transforms this function, so that it returns it's argument value, the current value of the variable.
+     * ```
+     * fun nullOutSpilledVariable(value: Any?): Any? = value
+     * ```
+     */
     private static class SpillingTransformer implements ClassFileTransformer {
         @Override
         public byte[] transform(final ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) {
@@ -46,7 +60,6 @@ public class SpilledVariablesTransformer {
             public NullOutSpilledVariableTransformer(MethodVisitor mv) {
                 super(Opcodes.API_VERSION, mv);
             }
-
             @Override
             public void visitCode() {
                 super.visitCode();


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/IDEA-362006

> Note that even though the change in [KT-63720](https://youtrack.jetbrains.com/issue/KT-63720/Coroutine-debugger-do-not-optimise-out-local-variables) has landed in `2.1.20`, it will only have effect since `2.2.0`, because it relies on a new runtime function, which will only be accessible since `2.2.0`.