### PR TITLE
WIP: fixing async stack traces

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,9 @@ plugins {
 apply plugin: 'maven-publish'
 
 // BUILD_NUMBER env is set by TeamCity
-version = System.getenv("BUILD_NUMBER") ?: "1.0-SNAPSHOT"
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
+version = System.getenv("BUILD_NUMBER") ?: "1.9-my-SNAPSHOT"
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
     implementation files("lib/asm-capture-9.6.1.jar")

--- a/src/main/java/com/intellij/rt/debugger/agent/CaptureAgent.java
+++ b/src/main/java/com/intellij/rt/debugger/agent/CaptureAgent.java
@@ -381,7 +381,7 @@ public final class CaptureAgent {
       if (CaptureStorage.DEBUG) {
         System.out.println("Capture agent: retransforming " + classes);
       }
-
+      System.out.println("aaaaa still ok");
       ourInstrumentation.retransformClasses(classes.toArray(new Class[0]));
     }
   }
@@ -413,6 +413,7 @@ public final class CaptureAgent {
       myInstrumentPoints.put(className, points);
     }
     InstrumentPoint point = new InstrumentPoint(capture, className, methodName, methodDesc, keyProvider);
+    System.out.println("Capture agent: added point " + point);
     points.add(point);
     return point;
   }

--- a/src/main/java/com/intellij/rt/debugger/agent/CaptureStorage.java
+++ b/src/main/java/com/intellij/rt/debugger/agent/CaptureStorage.java
@@ -119,10 +119,6 @@ public final class CaptureStorage {
             }
             System.out.println("--------------------INSERT ENTER END:" + "CURRENT_STACKS.size" +  currentStacks.size() +"------------------------------------------");
           }
-//          if (DEBUG) {
-//            System.out.println(
-//                    "insert " + getCallerDescriptorForLogging() + " -> " + getKeyText(key) + ", stack saved (" + currentStacks.size() + ")");
-//          }
         }
         catch (Exception e) {
           handleException(e);
@@ -166,6 +162,10 @@ public final class CaptureStorage {
       @Override
       public Object call() {
         try {
+          Class<?> coroutineStackFrame = Class.forName("kotlin.coroutines.jvm.internal.CoroutineStackFrame", false, key.getClass().getClassLoader());
+          if (!coroutineStackFrame.isInstance(key)) {
+            return null;
+          }
           Method getCallerFrameMethod = getGetCallerFrameMethod(key);
           Object res = key;
           while (true) {
@@ -337,7 +337,15 @@ public final class CaptureStorage {
       }
       return stack;
     }
-    return new ExceptionCapturedStack(exception);
+    ExceptionCapturedStack exceptionStack = new ExceptionCapturedStack(exception);
+    System.out.println("BTW --- AAA: exception captured stack trace: \n " + exceptionStack.stringRepr()+ "----- \n");
+    return exceptionStack;
+  }
+
+  private static CapturedStack createExceptionCapturedStack(Throwable exception) {
+    ExceptionCapturedStack exceptionStack = new ExceptionCapturedStack(exception);
+    System.out.println("createExceptionCapturedStack: --- AAA: exception captured stack trace: \n " + exceptionStack.stringRepr()+ "----- \n");
+    return exceptionStack;
   }
 
   private interface CapturedStack {


### PR DESCRIPTION
Previously, we captured stack trace when the new coroutine was created (intercepting the `CoroutineOwner.<init>` call),
the captured frames were added to the stack when the coroutine (corresponding to the `CoroutineOwner`) was resumed, and removed when the coroutine was suspended.
E.g.
```kotlin
runBlocking { // capture Coroutine1
  foo {
    //Breakpoint! 
    println() // insert frames of Coroutine1
  }
}
```
The stack trace would be:
```
println()
foo
runBlocking // this frame was saved when Coroutine1 was created
```

But there are coroutine builders, like `withContext`, which do not create a new coroutine,
but create a new instance of suspendable computation and dispatch it for execution.
E.g.

```kotlin
runBlocking { // capture Coroutine1
   foo {
      withContext(Dispatchers.Default) {
        //Breakpoint!
        println()  // insert frames of Coroutine1 (only one frame was captured)
      }
   }
}
```
With the previous solution the stack trace would be:
```
println()
runBlocking
```

If we capture the corotuine frames every time it's execution is dispatched (every time when createCoroutineUnintercepted is invoked),
then we will not lose all the intermediate frames. In the case above:

```kotlin
runBlocking { // capture stack for Coroutine1
   foo {
      withContext(Dispatchers.Default) { // still the same coroutine but dispatched, capture stack for Coroutine1
         //Breakpoint!
         println()  // insert frames of Coroutine1 (only one frame was captured)
      }
  }
}
```
The stack trace is now:
```
   println()
   withContext
   foo
  runBlocking
```