### PR TITLE
Store async stack traces for all the threads.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew build
     - name: Publish artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: dist
         path: build/libs/*


### PR DESCRIPTION
Added an option to store async stack traces for all the threads in a map.

* It can be used to show async stack traces for coroutines in the coroutine dump: using one evaluation context we would be able to get captured stack traces for all running coroutines.

* And we'll be able to show async stack traces for all the threads when on a breakpoint in the Threads View

I haven't investigated the impact on performance yet though.